### PR TITLE
Properly append redirect location query string

### DIFF
--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -5,7 +5,6 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Web;
-using System.Xml;
 using ITfoxtec.Saml2.Schemas;
 using ITfoxtec.Saml2.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -40,11 +39,17 @@ namespace ITfoxtec.Saml2.Bindings
                 requestQueryString = SigneQueryString(requestQueryString, signingCertificate);
             }
 
-            RedirectLocation = new Uri(string.Join("?", saml2RequestResponse.Destination.Uri.OriginalString, requestQueryString));
-
+            if (string.IsNullOrWhiteSpace(saml2RequestResponse.Destination.Uri.Query))
+            {
+               RedirectLocation = new Uri( saml2RequestResponse.Destination.Uri.OriginalString + "?" + requestQueryString);
+            }
+            else
+            {
+               RedirectLocation = new Uri(saml2RequestResponse.Destination.Uri.OriginalString + "?" + saml2RequestResponse.Destination.Uri.Query + "&" + requestQueryString);
+            }
             return this;
         }
-        
+
         private string SigneQueryString(string queryString, X509Certificate2 signingCertificate)
         {
             var saml2Signed = new Saml2Sign(signingCertificate.PrivateKey);

--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -63,7 +63,7 @@ namespace ITfoxtec.Saml2.Bindings
             if (!string.IsNullOrWhiteSpace(RelayState))
             {
                 var relayState = HttpUtility.UrlEncode(RelayState);
-                if (relayState != null)
+                if (!string.IsNullOrWhiteSpace(relayState))
                 {
                    queryString.Add(Saml2Constants.Message.RelayState, relayState);
                 }
@@ -72,7 +72,7 @@ namespace ITfoxtec.Saml2.Bindings
             if(signingCertificate != null)
             {
                 var signatureAlgorithm = HttpUtility.UrlEncode(signingCertificate.PrivateKey.SignatureAlgorithm);
-                if (signatureAlgorithm != null)
+                if (!string.IsNullOrWhiteSpace(signatureAlgorithm))
                 {
                    queryString.Add(Saml2Constants.Message.SigAlg, signatureAlgorithm);
                 }

--- a/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
+++ b/ITfoxtec.Saml2/Bindings/Saml2RedirectBinding.cs
@@ -36,13 +36,8 @@ namespace ITfoxtec.Saml2.Bindings
             var uriBuilder = new UriBuilder(saml2RequestResponse.Destination.Uri.OriginalString);
             NameValueCollection queryString = HttpUtility.ParseQueryString(uriBuilder.Query);
             queryString.Add(RequestQueryString(signingCertificate, messageName));
-
-            if (signingCertificate != null)
-            {
-               queryString.Add(Saml2Constants.Message.Signature, SigneQueryString(queryString.ToString(),signingCertificate));
-            }
-
             uriBuilder.Query = queryString.ToString();
+
             RedirectLocation = uriBuilder.Uri;
             return this;
         }
@@ -81,8 +76,10 @@ namespace ITfoxtec.Saml2.Bindings
                 {
                    queryString.Add(Saml2Constants.Message.SigAlg, signatureAlgorithm);
                 }
+
+                queryString.Add(Saml2Constants.Message.Signature, SigneQueryString(queryString.ToString(),signingCertificate));
             }
-           return queryString;
+            return queryString;
         }
 
         private string CompressRequest()


### PR DESCRIPTION
Currently, `BindInternal` assumes `saml2RequestResponse.Destination.Uri.OriginalString` does not contain a query string. In the case where a query string is already present, `BindInternal` will create a bad URL by improperly constructing the query string. This PR addresses such a possibility by using a `UriBuilder` and `NameValueCollection` to build the `RedirectLocation` and its associated query string.
