### PR TITLE
Handle issuer without scheme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+.vs/
 
 # Build results
 
@@ -14,6 +15,7 @@ x64/
 build/
 [Bb]in/
 [Oo]bj/
+packages/
 
 # Enable "build/" folder in the NuGet Packages folder since NuGet packages use it for MSBuild targets
 !packages/*/build/

--- a/ITfoxtec.Saml2/Saml2Request.cs
+++ b/ITfoxtec.Saml2/Saml2Request.cs
@@ -164,7 +164,15 @@ namespace ITfoxtec.Saml2
             var issuerString = XmlDocument.DocumentElement[Saml2Constants.Message.Issuer, Saml2Constants.AssertionNamespace.OriginalString].GetTextOrNull();
             if (!string.IsNullOrEmpty(issuerString))
             {
-                Issuer = new EndpointReference(issuerString);
+                try
+                {
+                   Uri issuerUri = new UriBuilder( issuerString ).Uri;
+                   Issuer = new EndpointReference( issuerUri.AbsoluteUri );
+                }
+                catch ( Exception ex )
+                {
+                   Trace.TraceError( "Could not format issuer as a URI, issuer: {0} exception: {1}", issuerString, ex );
+                }
             }
 
             var destinationString = XmlDocument.DocumentElement.Attributes[Saml2Constants.Message.Destination].GetValueOrNull();


### PR DESCRIPTION
The issuer is an optional part of the SAML2 response and is not required to be a URI. Because this library is built on those assumptions if we get an issuer that is not a valid URI just log the details rather than blowing up.